### PR TITLE
Get document root from server

### DIFF
--- a/Error/Processor.php
+++ b/Error/Processor.php
@@ -435,8 +435,8 @@ class Processor
     protected function _getIndexDir()
     {
         $documentRoot = '';
-        if (!empty($this->request->getParam('DOCUMENT_ROOT'))) {
-            $documentRoot = rtrim(realpath($this->request->getParam('DOCUMENT_ROOT')), '/');
+        if (!empty($this->request->getServer('DOCUMENT_ROOT'))) {
+            $documentRoot = rtrim(realpath($this->request->getServer('DOCUMENT_ROOT')), '/');
         }
 
         return dirname($documentRoot . $this->_scriptName) . '/';


### PR DESCRIPTION
Change extraction method

### Description

In our server environment, the "Document Root" could not be read correctly.

Instead of reading the document root via "$this->request->getParam('DOCUMENT_ROOT')", the following command worked:

$this->request->getServer('DOCUMENT_ROOT')

This is also used by the Magento core:

https://github.com/magento/magento2/blob/c3ab314c5e51cb91c96f161d82db92370cd7d9b8/app/code/Magento/Sitemap/Model/Sitemap.php#L766

It is possible that other parameters are also affected:

REMOTE_ADDR
HTTP_HOST
SERVER_NAME